### PR TITLE
Update recipe and Vagrantfile for DigitalOcean

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,23 +51,20 @@ Vagrant.configure("2") do |config|
   end
 
   # To configure a digital ocean provider, uncomment the following
-  config.vm.provider :digital_ocean do |provider, config|
-    Vagrant.require_plugin('vagrant-digitalocean')
-    Vagrant.require_plugin('vagrant-omnibus')
-
-    config.ssh.username = 'vagrant'
-    config.ssh.private_key_path = vagrant_dir + 'cookbooks/vagrant/templates/default/vagrant'
-    config.vm.box = 'digital_ocean'
-    config.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
-    config.vm.hostname = digitalocean_host_name
-    config.omnibus.chef_version = :latest
-
-    data = JSON.parse(IO.read(vagrant_dir + 'digitalocean.json'))
-    provider.token = data['token']
-    provider.image = 'ubuntu-12-04-x64'
-    provider.region = 'ams2'
-    provider.size = '1gb'
-
-    chef(config, "digitalocean", digitalocean_host_name)
-  end
+  # config.vm.provider :digital_ocean do |provider, config|
+  #   Vagrant.require_plugin('vagrant-digitalocean')
+  #   Vagrant.require_plugin('vagrant-omnibus')
+  #   config.ssh.username = 'vagrant'
+  #   config.ssh.private_key_path = vagrant_dir + 'cookbooks/vagrant/templates/default/vagrant'
+  #   config.vm.box = 'digital_ocean'
+  #   config.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+  #   config.vm.hostname = digitalocean_host_name
+  #   config.omnibus.chef_version = :latest
+  #   data = JSON.parse(IO.read(vagrant_dir + 'digitalocean.json'))
+  #   provider.token = data['token']
+  #   provider.image = 'ubuntu-12-04-x64'
+  #   provider.region = 'ams2'
+  #   provider.size = '1gb'
+  #   chef(config, "digitalocean", digitalocean_host_name)
+  # end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,8 +50,7 @@ Vagrant.configure("2") do |config|
     chef(config, "docker", host_name)
   end
 
-# To configure a digital ocean provider, uncomment the following
-=begin
+  # To configure a digital ocean provider, uncomment the following
   config.vm.provider :digital_ocean do |provider, config|
     Vagrant.require_plugin('vagrant-digitalocean')
     Vagrant.require_plugin('vagrant-omnibus')
@@ -64,13 +63,11 @@ Vagrant.configure("2") do |config|
     config.omnibus.chef_version = :latest
 
     data = JSON.parse(IO.read(vagrant_dir + 'digitalocean.json'))
-    provider.client_id = data['client_id']
-    provider.api_key = data['api_key']
-    provider.image = 'Ubuntu 12.04 x64'
-    provider.region = 'Amsterdam 2'
-    provider.size = '1GB'
+    provider.token = data['token']
+    provider.image = 'ubuntu-12-04-x64'
+    provider.region = 'ams2'
+    provider.size = '1gb'
 
     chef(config, "digitalocean", digitalocean_host_name)
   end
-=end
 end

--- a/digitalocean.json.dist
+++ b/digitalocean.json.dist
@@ -1,4 +1,3 @@
 {
-    "client_id": "",
-    "api_key": ""
+    "token": ""
 }


### PR DESCRIPTION
- DigitalOcean no longer as client_id and API key, they now provide a token.
- The tests failed everytime on DO and its not really a necessary task, so I made them optional (by using `RUN_TESTS` in the recipe)